### PR TITLE
fix temporary timers

### DIFF
--- a/lib/ecspanse/system/timer.ex
+++ b/lib/ecspanse/system/timer.ex
@@ -75,7 +75,7 @@ defmodule Ecspanse.System.Timer do
       end)
 
     Ecspanse.Command.update_components!(update)
-    Ecspanse.Command.remove_component!(remove)
+    Ecspanse.Command.remove_components!(remove)
   end
 
   defp build_event_spec(timer, entity) do


### PR DESCRIPTION
Turns out this happens when there is at least 1 `:temporary` timer is the system:

```
02:31:19.898 [error] Task #PID<0.4162.0> started from Ecspanse.Server terminating
** (KeyError) key :__meta__ not found in: []. If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
    (ecspanse 0.3.0) lib/ecspanse/command.ex:967: anonymous fn/1 in Ecspanse.Command.apply_operation/3
    (elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (ecspanse 0.3.0) lib/ecspanse/command.ex:967: Ecspanse.Command.apply_operation/3
    (ecspanse 0.3.0) lib/ecspanse/command.ex:386: Ecspanse.Command.remove_components!/1
    (elixir 1.14.5) lib/enum.ex:980: anonymous fn/3 in Enum.each/2
    (stdlib 4.3.1.2) maps.erl:411: :maps.fold_1/3
    (elixir 1.14.5) lib/enum.ex:2480: Enum.each/2
    (ecspanse 0.3.0) lib/ecspanse/server.ex:440: anonymous fn/2 in Ecspanse.Server.run_system/2
Function: #Function<11.95439573/0 in Ecspanse.Server.run_system/2>
    Args: []
```

Almost went insane trying to trace this error back to this line :) 
Btw thanks for this awesome library. It's really well thought out
